### PR TITLE
Support URL namespaces and app_names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ Django template tags to add active class on navigation menus
 Prerequisites
 -------------
 
--  Django 1.6, 1.7, 1.8
--  Python 2.7, 3.2, 3.3, 3.4
+-  Django 1.6, 1.7, 1.8, 1.9, 1.10
+-  Python 2.7, 3.2, 3.3, 3.4, 3.5
 
 Installation
 ------------
@@ -48,7 +48,7 @@ of view names
 .. code-block:: html
 
     {% load navactive %}
-    <li class="{% navactive request "view_name another_view_name" %}">
+    <li class="{% navactive request "view_name app_name:another_view_name namespace:" %}">
         <a href="{% url "view_name" }">Menu Entry</a>
     </li>
 

--- a/src/geelweb/django/navhelper/templatetags/navactive.py
+++ b/src/geelweb/django/navhelper/templatetags/navactive.py
@@ -30,7 +30,9 @@ def navactive(request, urls):
     if resolved.namespaces:
         resolved_urls = resolved_urls.union(["{}:{}".format(namespace, resolved.url_name) for namespace in resolved.namespaces])
         resolved_urls = resolved_urls.union(["{}:".format(namespace) for namespace in resolved.namespaces])
-    if resolved.app_names:
+    if getattr(resolved, 'app_name', None):
+        resolved_urls = resolved_urls.union(["{}:{}".format(resolved.app_name, resolved.url_name), "{}:".format(resolved.app_name)])
+    if getattr(resolved, 'app_names', []):
         resolved_urls = resolved_urls.union(["{}:{}".format(app_name, resolved.url_name) for app_name in resolved.app_names])
         resolved_urls = resolved_urls.union(["{}:".format(app_name) for app_name in resolved.app_names])
     if url_list and resolved_urls and bool(resolved_urls & url_list):

--- a/src/geelweb/django/navhelper/templatetags/navactive.py
+++ b/src/geelweb/django/navhelper/templatetags/navactive.py
@@ -5,6 +5,7 @@ import re
 
 register = Library()
 
+
 @register.simple_tag
 def renavactive(request, pattern):
     """
@@ -14,13 +15,25 @@ def renavactive(request, pattern):
         return getattr(settings, "NAVHELPER_ACTIVE_CLASS", "active")
     return getattr(settings, "NAVHELPER_NOT_ACTIVE_CLASS", "")
 
+
 @register.simple_tag
 def navactive(request, urls):
     """
     {% navactive request "view_name another_view_name" %}
     """
-    url_name = resolve(request.path).url_name
-    if url_name in urls.split():
+    url_list = set(urls.split())
+
+    resolved = resolve(request.path)
+    resolved_urls = set()
+    if resolved.url_name:
+        resolved_urls.add(resolved.url_name)
+    if resolved.namespaces:
+        resolved_urls = resolved_urls.union(["{}:{}".format(namespace, resolved.url_name) for namespace in resolved.namespaces])
+        resolved_urls = resolved_urls.union(["{}:".format(namespace) for namespace in resolved.namespaces])
+    if resolved.app_names:
+        resolved_urls = resolved_urls.union(["{}:{}".format(app_name, resolved.url_name) for app_name in resolved.app_names])
+        resolved_urls = resolved_urls.union(["{}:".format(app_name) for app_name in resolved.app_names])
+    if url_list and resolved_urls and bool(resolved_urls & url_list):
         return getattr(settings, "NAVHELPER_ACTIVE_CLASS", "active")
     return getattr(settings, "NAVHELPER_NOT_ACTIVE_CLASS", "")
 


### PR DESCRIPTION
These changes allow matching against urls in the form `namespace:view_name` as well as entire namespaces of the form `namespace:`

This is particularly useful in projects with generic view names behind namespaces such as `app_name:view` with multiple apps each having their own `view` url.